### PR TITLE
Update uses of non-existant PORTLIBS_PATH variable

### DIFF
--- a/ds_rules
+++ b/ds_rules
@@ -4,8 +4,8 @@ endif
 
 include $(DEVKITARM)/base_rules
 
-PORTLIBS	:=	$(PORTLIBS_PATH)/nds $(PORTLIBS_PATH)/armv5te $(PORTLIBS_PATH)/armv4t
-export PATH := $(PORTLIBS_PATH)/nds/bin:$(PORTLIBS_PATH)/armv5te:$(PORTLIBS_PATH)/armv4t/bin:$(PATH)
+PORTLIBS	:=	$(DEVKITPRO)/portlibs/nds $(DEVKITPRO)/portlibs/armv5te $(DEVKITPRO)/portlibs/armv4t
+export PATH := $(DEVKITPRO)/portlibs/nds/bin:$(DEVKITPRO)/portlibs/armv5te:$(DEVKITPRO)/portlibs/armv4t/bin:$(PATH)
 
 LIBNDS		:=	$(DEVKITPRO)/libnds
 

--- a/gba_rules
+++ b/gba_rules
@@ -4,8 +4,8 @@ endif
 
 include $(DEVKITARM)/base_rules
 
-PORTLIBS	:= $(PORTLIBS_PATH)/gba $(PORTLIBS_PATH)/armv4t
-export PATH := $(PORTLIBS_PATH)/gba/bin:$(PORTLIBS_PATH)/armv4t/bin:$(PATH)
+PORTLIBS	:= $(DEVKITPRO)/portlibs/gba $(DEVKITPRO)/portlibs/armv4t
+export PATH := $(DEVKITPRO)/portlibs/gba/bin:$(DEVKITPRO)/portlibs/armv4t/bin:$(PATH)
 LIBGBA		:= $(DEVKITPRO)/libgba
 
 ifeq ($(strip $(GAME_TITLE)),)

--- a/gp32_rules
+++ b/gp32_rules
@@ -1,7 +1,7 @@
 -include $(DEVKITARM)/base_rules
 
-PORTLIBS	:=	$(PORTLIBS_PATH)/gp32 $(PORTLIBS_PATH)/armv4t
-export PATH := $(PORTLIBS_PATH)/gp32/bin:$(PORTLIBS_PATH)/armv4t/bin:$(PATH)
+PORTLIBS	:=	$(DEVKITPRO)/portlibs/gp32 $(DEVKITPRO)/portlibs/armv4t
+export PATH := $(DEVKITPRO)/portlibs/gp32/bin:$(DEVKITPRO)/portlibs/armv4t/bin:$(PATH)
 LIBMIRKO	:=	$(DEVKITPRO)/libmirko
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
The variable was removed in 7331d0277ca1a68dec82d284a3b9839f82233947 however there were some uses of the variable that were not updated.

As pointed out in https://github.com/devkitPro/devkitarm-rules/commit/7331d0277ca1a68dec82d284a3b9839f82233947#commitcomment-121557753