### PR TITLE
Removed spurious quotes on error messages.

### DIFF
--- a/3ds_rules
+++ b/3ds_rules
@@ -1,5 +1,5 @@
 ifeq ($(strip $(DEVKITPRO)),)
-$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
+$(error Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
 endif
 
 PORTLIBS	:=	$(DEVKITPRO)/portlibs/3ds

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ _PATCH	:= 0
 FILES	:=	3ds_rules  base_rules  base_tools  ds_rules  gba_rules  gp32_rules
 
 all:
-	@echo "use dist or install targets"
+	$(error use dist or install targets)
 
 install:
 	@mkdir -p $(DESTDIR)/opt/devkitpro/devkitARM

--- a/ds_rules
+++ b/ds_rules
@@ -1,5 +1,5 @@
 ifeq ($(strip $(DEVKITPRO)),)
-$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
+$(error Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
 endif
 
 PORTLIBS	:=	$(DEVKITPRO)/portlibs/nds $(DEVKITPRO)/portlibs/armv5te $(DEVKITPRO)/portlibs/armv4t

--- a/gba_rules
+++ b/gba_rules
@@ -1,5 +1,5 @@
 ifeq ($(strip $(DEVKITPRO)),)
-$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
+$(error Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
 endif
 
 

--- a/gp32_rules
+++ b/gp32_rules
@@ -1,5 +1,5 @@
 ifeq ($(strip $(DEVKITPRO)),)
-$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
+$(error Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPro)
 endif
 
 PORTLIBS	:=	$(DEVKITPRO)/portlibs/gp32 $(DEVKITPRO)/portlibs/armv4t


### PR DESCRIPTION
This PR removes the unbalanced opening quote in error messages.
It also changes the `@echo` line in the `Makefile` by a more appropriate use of `$(error)`.